### PR TITLE
Add Ruby http-signature library

### DIFF
--- a/frontend/src/components/libraries.js
+++ b/frontend/src/components/libraries.js
@@ -74,6 +74,15 @@ const libraryList = [
     verify: true
   },
   {
+    language: 'Ruby',
+    maintainer: 'Joel Larsson',
+    repo: 'https://github.com/bolmaster2/http-signature',
+    request: true,
+    response: true,
+    sign: true,
+    verify: true
+  },
+  {
     language: 'NodeJS',
     maintainer: 'Misskey Project',
     maintainerLink: 'https://misskey-hub.net/en/',


### PR DESCRIPTION
Adds [http_signature](https://github.com/bolmaster2/http-signature) Ruby gem which implements RFC 9421